### PR TITLE
Extract swiftlint to command

### DIFF
--- a/@orb.yml
+++ b/@orb.yml
@@ -19,6 +19,20 @@ examples:
           jobss:
             - swift/lint
 
+commands:
+  swiftlint:
+    description: "Runs swiftlint on the current directory"
+    parameters:
+      reportFile:
+        type: string
+        default: result.xml
+    steps:
+      - run: swiftlint lint --reporter junit | tee << parameters.reportFile >>
+      - store_artifacts:
+        path: << parameters.reportFile >>
+      - store_test_results:
+        path: << parameters.reportFile >>
+
 jobs:
   lint:
     description: Run `swiftlint` over the repository.
@@ -26,8 +40,4 @@ jobs:
       - image: dantoml/swiftlint:latest
     steps:
       - checkout
-      - run: swiftlint lint --reporter junit | tee result.xml
-      - store_artifacts:
-          path: result.xml
-      - store_test_results:
-          path: result.xml
+      - swiftlint


### PR DESCRIPTION
Fixes #3 

Also, I noticed, that `circleci orb validate @orb.yml` does not work since `standard-swift-project` has no `jobs`