### PR TITLE
Change License to (c) CircleCI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Swift Orb
+Copyright (c) 2019 CircleCI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The copyright for this Orb should not be "Swift Orb", rather CircleCI, CircleCI Public, or something similar.